### PR TITLE
Scalar nonlinear solve AD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Reexport = "0.2"
 Setfield = "0.7"
 StaticArrays = "0.11, 0.12"
 UnPack = "0.1, 1.0"
+julia = "1"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -3,6 +3,7 @@ module NonlinearSolve
   using Reexport
   using UnPack: @unpack
   using FiniteDiff, ForwardDiff
+  using ForwardDiff: Dual
   using Setfield
   using StaticArrays
   using RecursiveArrayTools

--- a/src/types.jl
+++ b/src/types.jl
@@ -78,3 +78,6 @@ function sync_residuals!(solver::BracketingImmutableSolver)
     @set! solver.fr = solver.f(solver.right, solver.p)
     solver
 end
+
+getsolution(sol::NewtonSolution) = sol.u
+getsolution(sol::BracketingSolution) = sol.left

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -234,3 +234,7 @@ function value_derivative(f::F, x::R) where {F,R}
     out = f(ForwardDiff.Dual{T}(x, one(x)))
     ForwardDiff.value(out), ForwardDiff.extract_derivative(T, out)
 end
+
+value(x) = x
+value(x::Dual) = ForwardDiff.value(x)
+value(x::AbstractArray{<:Dual}) = map(ForwardDiff.value, x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -216,7 +216,7 @@ Move `x` one floating point towards x0.
 function prevfloat_tdir(x::T, x0::T, x1::T)::T where {T}
   x1 > x0 ? prevfloat(x) : nextfloat(x)
 end
-  
+
 function nextfloat_tdir(x::T, x0::T, x1::T)::T where {T}
   x1 > x0 ? nextfloat(x) : prevfloat(x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,23 @@ for p in 1.1:0.1:100.0
     @test ForwardDiff.derivative(g, p) ≈ 1/(2*sqrt(p))
 end
 
+f, u0 = (u, p) -> p[1] * u * u - p[2], (1.0, 100.0)
+t = (p) -> [sqrt(p[2] / p[1])]
+g = function (p)
+    probN = NonlinearProblem{false}(f, u0, p)
+    sol = solve(probN, Bisection())
+    return [sol.left]
+end
+
+for p1 in 1.0:1.0:100.0
+    for p2 in 1.0:1.0:100.0
+        p = [p1, p2]
+        @show p
+        @test g(p) ≈ [sqrt(p[2] / p[1])]
+        @test ForwardDiff.jacobian(g, p) ≈ ForwardDiff.jacobian(t, p)
+    end
+end
+
 # Error Checks
 
 f, u0 = (u, p) -> u .* u .- 2.0, @SVector[1.0, 1.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,20 +71,26 @@ end
 
 f, u0 = (u, p) -> p[1] * u * u - p[2], (1.0, 100.0)
 t = (p) -> [sqrt(p[2] / p[1])]
-g = function (p)
-    probN = NonlinearProblem{false}(f, u0, p)
-    sol = solve(probN, Bisection())
-    return [sol.left]
+p = [0.9, 50.0]
+for alg in [Bisection(), Falsi()]
+    global g, p
+    g = function (p)
+        probN = NonlinearProblem{false}(f, u0, p)
+        sol = solve(probN, Bisection())
+        return [sol.left]
+    end
+
+    @test g(p) ≈ [sqrt(p[2] / p[1])]
+    @test ForwardDiff.jacobian(g, p) ≈ ForwardDiff.jacobian(t, p)
 end
 
-for p1 in 1.0:1.0:100.0
-    for p2 in 1.0:1.0:100.0
-        p = [p1, p2]
-        @show p
-        @test g(p) ≈ [sqrt(p[2] / p[1])]
-        @test ForwardDiff.jacobian(g, p) ≈ ForwardDiff.jacobian(t, p)
-    end
+gnewton = function (p)
+    probN = NonlinearProblem{false}(f, 0.5, p)
+    sol = solve(probN, NewtonRaphson())
+    return [sol.u]
 end
+@test gnewton(p) ≈ [sqrt(p[2] / p[1])]
+@test ForwardDiff.jacobian(gnewton, p) ≈ ForwardDiff.jacobian(t, p)
 
 # Error Checks
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,12 +57,12 @@ end
 f, u0 = (u, p) -> u * u - p, 1.0
 
 g = function (p)
-    probN = NonlinearProblem{false}(f, u0, p)
+    probN = NonlinearProblem{false}(f, oftype(p, u0), p)
     sol = solve(probN, NewtonRaphson())
     return sol.u
 end
 
-@test_broken ForwardDiff.derivative(g, 1.0) ≈ 0.5
+@test ForwardDiff.derivative(g, 1.0) ≈ 0.5
 
 for p in 1.1:0.1:100.0
     @test g(p) ≈ sqrt(p)


### PR DESCRIPTION
This PR adds forward mode AD overloads for scalar nonlinear equation solvers, i.e. `NewtonRaphson`, `Falsi`, and `Bisection`.