### PR TITLE
bump compat version bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,8 @@ ForwardDiff = "0.10.3"
 RecursiveArrayTools = "2"
 Reexport = "0.2"
 Setfield = "0.7"
-StaticArrays = "0.11, 0.12"
-UnPack = "0.1, 1.0"
+StaticArrays = "1.0"
+UnPack = "1.0"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
If tests pass, there should be a new release of NonlinearSolve.jl since it holds back updates for DiffEqBase.jl (https://github.com/SciML/DiffEqBase.jl/pull/604) which in turns holds back updates for a lot of downstream packages.

This needs a new version of RecursiveArrayTools.jl (https://github.com/SciML/RecursiveArrayTools.jl/pull/123).