### PR TITLE
loosen types on prev/next floating handling

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -213,15 +213,15 @@ const DEFAULT_LINSOLVE = DefaultLinSolve()
 
 Move `x` one floating point towards x0.
 """
-function prevfloat_tdir(x::T, x0::T, x1::T)::T where {T}
+function prevfloat_tdir(x, x0, x1)
   x1 > x0 ? prevfloat(x) : nextfloat(x)
 end
 
-function nextfloat_tdir(x::T, x0::T, x1::T)::T where {T}
+function nextfloat_tdir(x, x0, x1)
   x1 > x0 ? nextfloat(x) : prevfloat(x)
 end
 
-function max_tdir(a::T, b::T, x0::T1, x1::T1)::T where {T, T1}
+function max_tdir(a, b, x0, x1)
   x1 > x0 ? max(a, b) : min(a, b)
 end
 


### PR DESCRIPTION
Is there a reason why they were so tight?